### PR TITLE
feat: implement functional multi-view unlink feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lazylabel-gui"
-version = "1.3.6"
+version = "1.3.7"
 authors = [
   { name="Deniz N. Cakan", email="deniz.n.cakan@gmail.com" },
 ]

--- a/src/lazylabel/ui/main_window.py
+++ b/src/lazylabel/ui/main_window.py
@@ -1582,6 +1582,19 @@ class MainWindow(QMainWindow):
         # Reset AI mode state
         self.ai_click_start_pos = None
 
+        # Reset all link states to linked when navigating to new images
+        config = self._get_multi_view_config()
+        num_viewers = config["num_viewers"]
+        self.multi_view_linked = [True] * num_viewers
+
+        # Reset unlink button appearances to default linked state
+        if hasattr(self, "multi_view_unlink_buttons"):
+            for i, button in enumerate(self.multi_view_unlink_buttons):
+                if i < num_viewers:
+                    button.setText("X")
+                    button.setToolTip("Unlink this image from mirroring")
+                    button.setStyleSheet("")
+
         # Update UI lists to reflect cleared state
         self._update_all_lists()
 
@@ -2829,7 +2842,8 @@ class MainWindow(QMainWindow):
         for i in range(num_viewers):
             image_path = self.multi_view_images[i]
 
-            if not image_path:
+            # Skip if no image or if this viewer is unlinked
+            if not image_path or not self.multi_view_linked[i]:
                 continue
 
             # Filter segments for this viewer
@@ -6802,21 +6816,20 @@ class MainWindow(QMainWindow):
 
     def _toggle_multi_view_link(self, image_index):
         """Toggle the link status for a specific image in multi-view."""
-        if 0 <= image_index < 2:
-            self.multi_view_linked[image_index] = not self.multi_view_linked[
-                image_index
-            ]
+        # Check bounds and link status - only allow unlinking when currently linked
+        if (
+            0 <= image_index < len(self.multi_view_linked)
+            and self.multi_view_linked[image_index]
+        ):
+            # Currently linked - allow unlinking
+            self.multi_view_linked[image_index] = False
 
-            # Update button appearance
+            # Update button appearance to show unlinked state
             button = self.multi_view_unlink_buttons[image_index]
-            if self.multi_view_linked[image_index]:
-                button.setText("X")
-                button.setToolTip("Unlink this image from mirroring")
-                button.setStyleSheet("")
-            else:
-                button.setText("↪")
-                button.setToolTip("Link this image to mirroring")
-                button.setStyleSheet("background-color: #ffcccc;")
+            button.setText("↪")
+            button.setToolTip("This image is unlinked from mirroring")
+            button.setStyleSheet("background-color: #ff4444; color: white;")
+        # If already unlinked or invalid index, do nothing (prevent re-linking)
 
     def _start_background_image_discovery(self):
         """Start background discovery of all image files."""

--- a/tests/unit/ui/test_4view_comprehensive.py
+++ b/tests/unit/ui/test_4view_comprehensive.py
@@ -53,6 +53,15 @@ def test_4view_polygon_mode_mirroring(main_window_4view):
     """Test that polygon mode mirrors to all 4 viewers in 4-view mode."""
     window = main_window_4view
 
+    # Set up proper multi-view state for the new link-aware implementation
+    window.multi_view_linked = [True, True, True, True]  # All viewers linked
+    window.multi_view_images = [
+        "img1.jpg",
+        "img2.jpg",
+        "img3.jpg",
+        "img4.jpg",
+    ]  # All have images
+
     # Create test polygon points for viewer 0
     test_points = [QPointF(10, 10), QPointF(50, 10), QPointF(50, 50), QPointF(10, 50)]
 
@@ -92,6 +101,15 @@ def test_4view_polygon_mode_mirroring(main_window_4view):
 def test_4view_bbox_mode_mirroring(main_window_4view):
     """Test that bbox mode mirrors to all 4 viewers in 4-view mode."""
     window = main_window_4view
+
+    # Set up proper multi-view state for the new link-aware implementation
+    window.multi_view_linked = [True, True, True, True]  # All viewers linked
+    window.multi_view_images = [
+        "img1.jpg",
+        "img2.jpg",
+        "img3.jpg",
+        "img4.jpg",
+    ]  # All have images
 
     # Initialize bbox arrays for 4 viewers
     window.multi_view_bbox_starts = [None] * 4


### PR DESCRIPTION
- Add red visual feedback for unlinked views (one-way operation)
- Skip unlinked views in annotation mirroring logic
- Skip unlinked views in save operations
- Reset link states when navigating to new images
- Support both 2-view and 4-view configurations
- Add comprehensive unit tests for all functionality
- Fix existing tests to work with link-aware behavior

The unlink feature now allows users to drop outlier images from multi-view sessions while maintaining proper state management.