### PR TITLE
feat: implement parallel multi-view image loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lazylabel-gui"
-version = "1.3.6"
+version = "1.3.8"
 authors = [
   { name="Deniz N. Cakan", email="deniz.n.cakan@gmail.com" },
 ]

--- a/src/lazylabel/ui/main_window.py
+++ b/src/lazylabel/ui/main_window.py
@@ -6279,22 +6279,23 @@ class MainWindow(QMainWindow):
             )
 
     def _start_sequential_multi_view_sam_loading(self):
-        """Start loading images into SAM models sequentially to avoid resource conflicts."""
+        """Start loading images into SAM models in parallel for faster processing."""
         # Check if any loading is already in progress to prevent duplicate workers
         any_updating = any(self.multi_view_models_updating)
         if any_updating:
-            # Sequential loading already in progress, don't start another
+            # Loading already in progress, don't start another
             updating_indices = [
                 i
                 for i, updating in enumerate(self.multi_view_models_updating)
                 if updating
             ]
             logger.debug(
-                f"Sequential loading already in progress for viewers: {updating_indices}"
+                f"Parallel loading already in progress for viewers: {updating_indices}"
             )
             return
 
-        # Find the next dirty model that needs updating
+        # Find all dirty models that need updating and start them in parallel
+        models_to_update = []
         for i in range(len(self.multi_view_models)):
             if (
                 self.multi_view_images[i]
@@ -6302,15 +6303,24 @@ class MainWindow(QMainWindow):
                 and self.multi_view_models_dirty[i]
                 and not self.multi_view_models_updating[i]
             ):
-                # Start updating this model
-                self._ensure_multi_view_sam_updated(i)
-                return
+                models_to_update.append(i)
 
-        # If no more models to update, we're done
-        if self._multi_view_loading_step >= self._multi_view_total_steps:
-            self._show_success_notification(
-                "AI models ready for prompting", duration=3000
+        if models_to_update:
+            logger.debug(f"Starting parallel loading for viewers: {models_to_update}")
+            # Show notification about parallel loading
+            self._show_notification(
+                f"Loading embeddings for {len(models_to_update)} images in parallel...",
+                duration=0,
             )
+            # Start all workers in parallel
+            for i in models_to_update:
+                self._ensure_multi_view_sam_updated(i)
+        else:
+            # If no more models to update and none are running, we're done
+            if not any(self.multi_view_models_updating):
+                self._show_success_notification(
+                    "AI models ready for prompting", duration=3000
+                )
 
     def _on_multi_view_init_error(self, error_message):
         """Handle multi-view model initialization error."""
@@ -6452,14 +6462,8 @@ class MainWindow(QMainWindow):
 
         logger.debug(f"Starting SAM image loading worker for viewer {viewer_index + 1}")
 
-        # Show enumerated progress notification
-        image_name = Path(image_path).name if image_path else "unknown"
-        config = self._get_multi_view_config()
-        num_viewers = config["num_viewers"]
-        self._show_notification(
-            f"Computing embeddings for image {viewer_index + 1}/{num_viewers}: {image_name}",
-            duration=0,  # Persistent until completion
-        )
+        # Individual notifications are now handled by the parallel loading start
+        # No need for per-viewer notifications when loading in parallel
 
         # Get current modified image if operate_on_view is enabled
         current_image = None
@@ -6547,8 +6551,16 @@ class MainWindow(QMainWindow):
         if hasattr(self, "_multi_view_loading_step"):
             self._multi_view_loading_step += 1
 
-        # Continue sequential loading
-        self._start_sequential_multi_view_sam_loading()
+        # Check if all models are done (either loaded, failed, or timed out)
+        if not any(self.multi_view_models_updating) and not any(
+            self.multi_view_models_dirty
+        ):
+            # All models processed
+            self._show_success_notification("AI model loading complete", duration=3000)
+        elif not any(self.multi_view_models_updating):
+            # No models are currently updating but some may still be dirty
+            # Try to load remaining models
+            self._start_sequential_multi_view_sam_loading()
 
     def _on_multi_view_sam_update_finished(self, viewer_index):
         """Handle completion of multi-view SAM model update."""
@@ -6582,14 +6594,19 @@ class MainWindow(QMainWindow):
         # Update progress
         if hasattr(self, "_multi_view_loading_step"):
             self._multi_view_loading_step += 1
-            if self._multi_view_loading_step < self._multi_view_total_steps:
-                self._show_notification(
-                    f"Loading image {self._multi_view_loading_step + 1} of {self._multi_view_total_steps}...",
-                    duration=0,
-                )
 
-        # Continue sequential loading of the next SAM model
-        self._start_sequential_multi_view_sam_loading()
+        # Check if all models are done loading
+        if not any(self.multi_view_models_updating) and not any(
+            self.multi_view_models_dirty
+        ):
+            # All models loaded successfully
+            self._show_success_notification(
+                "AI models ready for prompting", duration=3000
+            )
+        elif not any(self.multi_view_models_updating):
+            # No models are currently updating but some may still be dirty
+            # This can happen if there was an error, try to load remaining models
+            self._start_sequential_multi_view_sam_loading()
 
     def _on_multi_view_sam_update_error(self, viewer_index, error_message):
         """Handle multi-view SAM model update error."""
@@ -6625,8 +6642,16 @@ class MainWindow(QMainWindow):
         if hasattr(self, "_multi_view_loading_step"):
             self._multi_view_loading_step += 1
 
-        # Continue sequential loading even if this model failed
-        self._start_sequential_multi_view_sam_loading()
+        # Check if all models are done (either loaded or failed)
+        if not any(self.multi_view_models_updating) and not any(
+            self.multi_view_models_dirty
+        ):
+            # All models processed (some may have failed)
+            self._show_success_notification("AI model loading complete", duration=3000)
+        elif not any(self.multi_view_models_updating):
+            # No models are currently updating but some may still be dirty
+            # Try to load remaining models
+            self._start_sequential_multi_view_sam_loading()
 
     def _cleanup_multi_view_models(self):
         """Clean up multi-view model instances."""
@@ -6802,21 +6827,25 @@ class MainWindow(QMainWindow):
 
     def _toggle_multi_view_link(self, image_index):
         """Toggle the link status for a specific image in multi-view."""
-        if 0 <= image_index < 2:
+        config = self._get_multi_view_config()
+        num_viewers = config["num_viewers"]
+
+        if 0 <= image_index < num_viewers and image_index < len(self.multi_view_linked):
             self.multi_view_linked[image_index] = not self.multi_view_linked[
                 image_index
             ]
 
             # Update button appearance
-            button = self.multi_view_unlink_buttons[image_index]
-            if self.multi_view_linked[image_index]:
-                button.setText("X")
-                button.setToolTip("Unlink this image from mirroring")
-                button.setStyleSheet("")
-            else:
-                button.setText("↪")
-                button.setToolTip("Link this image to mirroring")
-                button.setStyleSheet("background-color: #ffcccc;")
+            if image_index < len(self.multi_view_unlink_buttons):
+                button = self.multi_view_unlink_buttons[image_index]
+                if self.multi_view_linked[image_index]:
+                    button.setText("X")
+                    button.setToolTip("Unlink this image from mirroring")
+                    button.setStyleSheet("")
+                else:
+                    button.setText("↪")
+                    button.setToolTip("Link this image to mirroring")
+                    button.setStyleSheet("background-color: #ffcccc;")
 
     def _start_background_image_discovery(self):
         """Start background discovery of all image files."""


### PR DESCRIPTION
Replace serial loading with parallel processing to eliminate 4x wait times in multi-view mode. All SAM model embeddings now compute simultaneously instead of sequentially.

Changes:
- Modified _start_sequential_multi_view_sam_loading to start all workers in parallel
- Updated completion handlers to track when all parallel workers finish
- Improved error handling for parallel loading scenarios
- Updated related unit tests to verify parallel behavior
- Bumped version to 1.3.8